### PR TITLE
refactor: upgrade plugin installer requirement to ~0.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 		}
 	],
 	"require": {
-		"roundcube/plugin-installer": "~0.2.0" 
+		"roundcube/plugin-installer": "~0.3.0" 
 	},
 	"extra": {
 		"roundcube": {


### PR DESCRIPTION
fixes installation on RC 1.6.6 (at least)